### PR TITLE
`details` functionality for error splashes. +Flow type fixes

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -11,4 +11,6 @@
 module.system.node.resolve_dirname=node_modules
 module.system.node.resolve_dirname=.
 
+module.name_mapper.extension='svg' -> '<PROJECT_ROOT>/src/SVGFlowStub.js'
+
 [strict]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Update letter spacing in Text styles
 
+- Fixed flow typing for SVG images and some other cases
+
+- Added details prop to SplashError
+
 ## [0.15.1] - 2020-04-09
 
 - Loading Button state looks more disabled than before

--- a/flow-typed/SVGGlyph.js
+++ b/flow-typed/SVGGlyph.js
@@ -1,0 +1,7 @@
+/* @flow */
+declare type SVGGlyph = {
+  content: string,
+  id: string,
+  node: SVGSymbolElement,
+  viewBox: string
+};

--- a/src/SVGFlowStub.js
+++ b/src/SVGFlowStub.js
@@ -1,0 +1,15 @@
+/* @flow */
+/*
+This file is used via .flowconfig:
+module.name_mapper.extension='svg' -> '<PROJECT_ROOT>/src/SVGFlowStub.js'
+*/
+
+const stub = {
+  viewBox: '',
+  id: ''
+};
+
+export type Glyph = typeof stub;
+
+// Flow will treat imports from '.svg' as if it were imports from this file
+export default stub;

--- a/src/SVGFlowStub.js
+++ b/src/SVGFlowStub.js
@@ -4,12 +4,12 @@ This file is used via .flowconfig:
 module.name_mapper.extension='svg' -> '<PROJECT_ROOT>/src/SVGFlowStub.js'
 */
 
-const stub = {
-  viewBox: '',
-  id: ''
+const stub: SVGGlyph = {
+  content: '',
+  id: '',
+  node: document.createElementNS('http://www.w3.org/2000/svg', 'symbol'),
+  viewBox: ''
 };
-
-export type Glyph = typeof stub;
 
 // Flow will treat imports from '.svg' as if it were imports from this file
 export default stub;

--- a/src/components/CopyToClipboard/index.js
+++ b/src/components/CopyToClipboard/index.js
@@ -5,21 +5,36 @@ import { withTooltip } from '../Tooltip';
 import { IconNewWindow } from '../Icon';
 
 export const copyToClipboard = (str: string) => {
+  if (!document.body) {
+    return;
+  }
+  // for Flow: prevent the refinement from invalidating
+  const body = document.body;
+
   const el = document.createElement('textarea');
   el.value = str;
   el.setAttribute('readonly', '');
   el.style.position = 'absolute';
   el.style.left = '-9999px';
-  document.body.appendChild(el);
-  const selected = document.getSelection().rangeCount > 0
-    ? document.getSelection().getRangeAt(0)
+  body.appendChild(el);
+
+  const currentSelection = document.getSelection();
+  const selected = (currentSelection && currentSelection.rangeCount > 0)
+    ? currentSelection.getRangeAt(0)
     : false;
   el.select();
   document.execCommand('copy');
-  document.body.removeChild(el);
+  body.removeChild(el);
   if (selected) {
-    document.getSelection().removeAllRanges();
-    document.getSelection().addRange(selected);
+    let currentSelection = document.getSelection();
+    if (currentSelection) {
+      currentSelection.removeAllRanges();
+    }
+
+    currentSelection = document.getSelection();
+    if (currentSelection) {
+      currentSelection.addRange(selected);
+    }
   }
 };
 

--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react'
 import { css, cx } from 'emotion';
+import { type Glyph } from '../../SVGFlowStub';
 // import { iconSize } from '../../variables';
 const iconSize = '14px';
 

--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -1,7 +1,6 @@
 // @flow
 import * as React from 'react'
 import { css, cx } from 'emotion';
-import { type Glyph } from '../../SVGFlowStub';
 // import { iconSize } from '../../variables';
 const iconSize = '14px';
 
@@ -61,7 +60,7 @@ const styles = {
 type IconProps = {
   active?: boolean; // Выбраное состояние
   className?: string;
-  glyph: Glyph,
+  glyph: SVGGlyph,
   hasState?: boolean, // Включение состояния: Normal, Hover, Active
   onClick?: (evt: MouseEvent) => void,
   onMouseEnter?: () => void,

--- a/src/components/NonIdealState/index.js
+++ b/src/components/NonIdealState/index.js
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import type { ComponentType } from 'react'
 import { css, cx } from 'emotion';
-import { type Glyph } from '../../SVGFlowStub';
 import { Button } from '../Button';
 import { Text } from '../Text';
 
@@ -41,7 +40,7 @@ type NonIdealStateProps = {
   children?: React.Node,
   className?: string,
   icon?: ComponentType<any>, // deprecated
-  image?: Glyph, // will be reqired
+  image?: SVGGlyph, // will be reqired
   title?: string,
   description?: string,
   isError?: bool,
@@ -87,7 +86,7 @@ type NonIdealStateActionProps = {
   className?: string,
   description?: string,
   icon?: ComponentType<any>, // deprecated
-  image?: Glyph, // will be reqired
+  image?: SVGGlyph, // will be reqired
   isError?: bool,
   onActionClick: (e: MouseEvent) => void,
   title: string,

--- a/src/components/NonIdealState/index.js
+++ b/src/components/NonIdealState/index.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import type { ComponentType } from 'react'
 import { css, cx } from 'emotion';
+import { type Glyph } from '../../SVGFlowStub';
 import { Button } from '../Button';
 import { Text } from '../Text';
 

--- a/src/components/SplashError/index.js
+++ b/src/components/SplashError/index.js
@@ -12,13 +12,17 @@ type Glyph = {
   id: string
 }
 
-type Props = {
+export type CommonSplashErrorProps = {
   title: string,
   description: string,
   details?: React.Node,
-  image?: Glyph,
   children?: React.Node,
 };
+
+type Props = CommonSplashErrorProps & {
+  image?: Glyph,
+}
+
 
 export const SplashError = (
   {

--- a/src/components/SplashError/index.js
+++ b/src/components/SplashError/index.js
@@ -1,24 +1,61 @@
 // @flow
 import * as React from 'react';
-import { NonIdealState } from '../NonIdealState';
+import { NonIdealState, NonIdealStateAction } from '../NonIdealState';
 import image from '../../images/window-shocked.svg';
+import { Button } from '../Button'
+import { Modal } from '../Modal';
 
 
 type Props = {
   title: string,
   description: string,
+  details?: React.Node,
+  children?: React.Node,
 };
 
 export const SplashError = (
   {
     description,
-    title
+    title,
+    details,
+    children
   }: Props
-) => (
-  <NonIdealState
-    isError
-    image={image}
-    title={title}
-    description={description}
-  />
-);
+) => {
+  const [showDetails, setShowDetails] = React.useState(false);
+  const onCloseClick = () => setShowDetails(false);
+
+  const commonProps = {
+    isError: true,
+    image,
+    title,
+    description,
+    children
+  };
+  return <>
+    {showDetails &&
+      <Modal
+        title={title}
+        onClose={onCloseClick}
+        footerControls={[
+          <Button intent={'primary'} onClick={onCloseClick}>Close</Button>
+        ]}
+      >
+        {details}
+      </Modal>
+    }
+
+    {details
+      ? (
+        <NonIdealStateAction
+          {...commonProps}
+          actionText="Details"
+          onActionClick={() => setShowDetails(true)}
+        />
+      ) : (
+        <NonIdealState
+          {...commonProps}
+        />
+      )
+    }
+  </>;
+}

--- a/src/components/SplashError/index.js
+++ b/src/components/SplashError/index.js
@@ -2,15 +2,10 @@
 import * as React from 'react';
 import { NonIdealState, NonIdealStateAction } from '../NonIdealState';
 import defaultImage from '../../images/window-shocked.svg';
+import { type Glyph } from '../../SVGFlowStub';
 import { Button } from '../Button'
 import { Modal } from '../Modal';
 
-
-//@TODO: refine, move for common use
-type Glyph = {
-  viewBox: string,
-  id: string
-}
 
 export type CommonSplashErrorProps = {
   title: string,

--- a/src/components/SplashError/index.js
+++ b/src/components/SplashError/index.js
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import { NonIdealState, NonIdealStateAction } from '../NonIdealState';
 import defaultImage from '../../images/window-shocked.svg';
-import { type Glyph } from '../../SVGFlowStub';
 import { Button } from '../Button'
 import { Modal } from '../Modal';
 
@@ -15,7 +14,7 @@ export type CommonSplashErrorProps = {
 };
 
 type Props = CommonSplashErrorProps & {
-  image?: Glyph,
+  image?: SVGGlyph,
 }
 
 

--- a/src/components/SplashError/index.js
+++ b/src/components/SplashError/index.js
@@ -1,15 +1,22 @@
 // @flow
 import * as React from 'react';
 import { NonIdealState, NonIdealStateAction } from '../NonIdealState';
-import image from '../../images/window-shocked.svg';
+import defaultImage from '../../images/window-shocked.svg';
 import { Button } from '../Button'
 import { Modal } from '../Modal';
 
+
+//@TODO: refine, move for common use
+type Glyph = {
+  viewBox: string,
+  id: string
+}
 
 type Props = {
   title: string,
   description: string,
   details?: React.Node,
+  image?: Glyph,
   children?: React.Node,
 };
 
@@ -18,6 +25,7 @@ export const SplashError = (
     description,
     title,
     details,
+    image,
     children
   }: Props
 ) => {
@@ -26,7 +34,7 @@ export const SplashError = (
 
   const commonProps = {
     isError: true,
-    image,
+    image: image || defaultImage,
     title,
     description,
     children

--- a/src/components/SplashError/index.js
+++ b/src/components/SplashError/index.js
@@ -47,7 +47,7 @@ export const SplashError = (
           <Button intent={'primary'} onClick={onCloseClick}>Close</Button>
         ]}
       >
-        {details}
+        {!!details && details}
       </Modal>
     }
 

--- a/src/components/SplashError/index.js
+++ b/src/components/SplashError/index.js
@@ -4,6 +4,7 @@ import { NonIdealState, NonIdealStateAction } from '../NonIdealState';
 import defaultImage from '../../images/window-shocked.svg';
 import { Button } from '../Button'
 import { Modal } from '../Modal';
+import { Text } from '../Text';
 
 
 export type CommonSplashErrorProps = {
@@ -46,7 +47,7 @@ export const SplashError = (
           <Button intent={'primary'} onClick={onCloseClick}>Close</Button>
         ]}
       >
-        {!!details && details}
+        {!!details && <Text tag='div'>{details}</Text>}
       </Modal>
     }
 

--- a/src/components/SplashError/readme.md
+++ b/src/components/SplashError/readme.md
@@ -1,6 +1,33 @@
 ```js
-<SplashError
-  title='Page not found'
-  description={'Sorry, the page you\'re looking for cannot be accessed.'}
-/>
+import { CopyToClipboard } from "../CopyToClipboard";
+
+<>
+  <SplashError
+    title="Page not found"
+    description={"Sorry, the page you're looking for cannot be accessed."}
+  />
+
+  <SplashError
+    title="Network error"
+    description="Failed to fetch"
+    details={`Error: Network error: Failed to fetch
+      at new ApolloError (http://localhost:3000/static/js/bundle.js:36545:24)
+      at http://localhost:3000/static/js/bundle.js:38034:32
+      at http://localhost:3000/static/js/bundle.js:38455:13
+      at Set.forEach (<anonymous>)
+      at http://localhost:3000/static/js/bundle.js:38453:24
+      at Map.forEach (<anonymous>)
+      at QueryManager.broadcastQueries (http://localhost:3000/static/js/bundle.js:38451:18)
+      at http://localhost:3000/static/js/bundle.js:37929:27"`}
+  />
+
+  <SplashError
+    title="With `children` prop"
+    description={"Let's use <CopyToClipboard> component as an example"}
+  >
+    <CopyToClipboard content="Hello, I`m copied text" size="s" intent="iconic">
+      Copy to Clipboard
+    </CopyToClipboard>
+  </SplashError>
+</>;
 ```

--- a/src/components/SplashErrorFatal/index.js
+++ b/src/components/SplashErrorFatal/index.js
@@ -1,24 +1,21 @@
 // @flow
 import * as React from 'react';
-import { NonIdealState } from '../NonIdealState';
+import { SplashError } from '../SplashError';
 import image from '../../images/window-dead.svg';
 
 
 type Props = {
   title: string,
   description: string,
+  details?: React.Node,
+  children?: React.Node,
 };
 
 export const SplashErrorFatal = (
-  {
-    description,
-    title
-  }: Props
+  props: Props
 ) => (
-  <NonIdealState
-    isError
+  <SplashError
+    {...props}
     image={image}
-    title={title}
-    description={description}
   />
 );

--- a/src/components/SplashErrorFatal/index.js
+++ b/src/components/SplashErrorFatal/index.js
@@ -1,18 +1,11 @@
 // @flow
 import * as React from 'react';
-import { SplashError } from '../SplashError';
+import { SplashError, type CommonSplashErrorProps } from '../SplashError';
 import image from '../../images/window-dead.svg';
 
 
-type Props = {
-  title: string,
-  description: string,
-  details?: React.Node,
-  children?: React.Node,
-};
-
 export const SplashErrorFatal = (
-  props: Props
+  props: CommonSplashErrorProps
 ) => (
   <SplashError
     {...props}

--- a/src/components/SplashErrorFatal/readme.md
+++ b/src/components/SplashErrorFatal/readme.md
@@ -1,6 +1,31 @@
 ```js
-<SplashErrorFatal
-  title='Artificial error'
-  description='An error ocurred and your request couldn’t be completed.'
-/>
+import { CopyToClipboard } from "../CopyToClipboard";
+
+<>
+  <SplashErrorFatal
+    title='Artificial error'
+    description='An error ocurred and your request couldn’t be completed.'
+  />
+
+  <SplashErrorFatal
+    title='Artificial error'
+    description="Failed to fetch"
+    details={<pre>{`Error: Network error: Failed to fetch
+  at new ApolloError (http://localhost:3000/static/js/bundle.js:36545:24) Very-very-very long string example
+  at http://localhost:3000/static/js/bundle.js:38034:32
+  at http://localhost:3000/static/js/bundle.js:38455:13
+  at Set.forEach (<anonymous>)
+  ...`}
+      </pre>}
+  />
+
+  <SplashErrorFatal
+    title="With `children` prop"
+    description={"Let's use <CopyToClipboard> component as an example"}
+  >
+    <CopyToClipboard content="Hello, I`m copied text" size="s" intent="iconic">
+      Copy to Clipboard
+    </CopyToClipboard>
+  </SplashErrorFatal>
+</>
 ```

--- a/src/components/SplashErrorNetwork/index.js
+++ b/src/components/SplashErrorNetwork/index.js
@@ -1,24 +1,15 @@
 // @flow
 import * as React from 'react';
-import { NonIdealState } from '../NonIdealState';
+import { SplashError, type CommonSplashErrorProps } from '../SplashError';
 import image from '../../images/window-no-network.svg';
 
 
-type Props = {
-  title?: string,
-  description: string
-};
-
 export const SplashErrorNetwork = (
-  {
-    title,
-    description
-  }: Props
+  props: CommonSplashErrorProps
 ) => (
-  <NonIdealState
-    isError
+  <SplashError
+    {...props}
+    title={props.title || 'Network problem'}
     image={image}
-    title={title || 'Network problem'}
-    description={description}
   />
 );

--- a/src/components/SplashErrorNetwork/readme.md
+++ b/src/components/SplashErrorNetwork/readme.md
@@ -1,9 +1,32 @@
 ```js
-<SplashErrorNetwork
-  description={<>
-    Sorry, the page you're looking for cannot be accessed.
-    <br />
-    Try reloading the page.
-  </>}
-/>
+import { CopyToClipboard } from "../CopyToClipboard";
+
+<>
+  <SplashErrorNetwork
+    description={<>
+      Sorry, the page you're looking for cannot be accessed.
+      <br />
+      Try reloading the page.
+    </>}
+  />
+
+  <SplashErrorNetwork
+    description="Failed to fetch"
+    details={<pre>{`Error: Network error: Failed to fetch
+  at new ApolloError (http://localhost:3000/static/js/bundle.js:36545:24) Very-very-very long string example
+  at http://localhost:3000/static/js/bundle.js:38034:32
+  at http://localhost:3000/static/js/bundle.js:38455:13
+  at Set.forEach (<anonymous>)
+  ...`}
+      </pre>}
+  />
+
+  <SplashErrorNetwork
+    description={"Let's use <CopyToClipboard> component as an example of `children` prop"}
+  >
+    <CopyToClipboard content="Hello, I`m copied text" size="s" intent="iconic">
+      Copy to Clipboard
+    </CopyToClipboard>
+  </SplashErrorNetwork>
+</>
 ```


### PR DESCRIPTION
• Fixed some flow type error (14 of 28)
• Introduced Glyph type for imported svg
• If SplashError, SplashErrorFatal, SplashErrorNetwork has `datails` prop, it will show "Details" button, showing modal with passed details

<img width="277" alt="изображение" src="https://user-images.githubusercontent.com/7147989/79435942-f3502200-7fd8-11ea-928c-e5d9561f79ef.png">
<img width="626" alt="изображение" src="https://user-images.githubusercontent.com/7147989/79436010-04992e80-7fd9-11ea-88ed-f19c32e7a9cc.png">
