### PR TITLE
Fix the SideMenu component.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Fix the SideMenu component. Now we don't render the href attribute if the menu item has children.
+If you want to use the old behavior, you can set the `forceToUseHrefAttribute` parameter to true. 
+
 ## [0.50.5] - 2021-12-28
 
 - Use css animation in the IconSpinner component.

--- a/src/components/AppLayout/__snapshots__/test.js.snap
+++ b/src/components/AppLayout/__snapshots__/test.js.snap
@@ -808,7 +808,6 @@ exports[`AppLayout renders correctly 1`] = `
       </a>
       <a
         className="emotion-5"
-        href="/other/test"
         onClick={[Function]}
         title="Other"
       >

--- a/src/components/SideMenu/SideMenu.types.ts
+++ b/src/components/SideMenu/SideMenu.types.ts
@@ -17,4 +17,5 @@ export type SideMenuItemType = {
   isSubitem?: boolean;
   isCollapse?: boolean;
   expand?: (evt: MouseEvent<HTMLElement>, path: string, expanded: boolean) => void;
+  forceToUseHrefAttribute?: boolean;
 };

--- a/src/components/SideMenu/components/SideMenuItem/SideMenuItem.tsx
+++ b/src/components/SideMenu/components/SideMenuItem/SideMenuItem.tsx
@@ -22,6 +22,7 @@ export const SideMenuItem = ({
   isCollapse,
   pathPrefix,
   type = 'internal',
+  forceToUseHrefAttribute = false,
 }: SideMenuItemType) => {
   const tag = path ? 'a' : 'button';
   const some = items && items.length > 0;
@@ -39,6 +40,11 @@ export const SideMenuItem = ({
     };
   }, [some, expand, onClick, path, type, expanded]);
 
+  let href: string | undefined = pathPrefix ? pathPrefix + path : path;
+  if (some && !forceToUseHrefAttribute) {
+    href = undefined;
+  }
+
   if (short) {
     const itemSelected = Boolean(selected || (items && items.find((x) => x.selected)));
     return (
@@ -48,7 +54,7 @@ export const SideMenuItem = ({
           [styles.itemSelected]: itemSelected,
         })}
         onClick={handleClick}
-        href={pathPrefix ? pathPrefix + path : path}
+        href={href}
         title={label}
       >
         <div className={styles.iconWrap}>
@@ -83,7 +89,7 @@ export const SideMenuItem = ({
           [styles.subItemSelected]: selected && isSubitem,
           [styles.collapse]: isCollapse,
         })}
-        href={pathPrefix ? pathPrefix + path : path}
+        href={href}
         onClick={handleClick}
         title={label}
       >

--- a/src/components/SideMenu/readme.md
+++ b/src/components/SideMenu/readme.md
@@ -38,44 +38,46 @@ const menu = [
       'selected': false,
       'expanded': true,
       'loading': false,
-      'items': [{
-        'selected': true,
-        'expanded': false,
-        'loading': false,
-        'items': [],
-        'label': 'My Test',
-        'path': '/mytest/test',
-        'namespace': 'mytest'
-      },
-      {
-        'selected': false,
-        'expanded': false,
-        'loading': false,
-        'items': [],
-        'icon': '',
-        'label': 'Other',
-        'path': '/other/test',
-        'namespace': 'other'
-      },
-      {
-        'selected': false,
-        'expanded': false,
-        'loading': false,
-        'items': [],
-        'icon': '',
-        'label': 'Other2',
-        'path': '/other/test2',
-        'namespace': 'other'
-      },
-      {
-        'selected': false,
-        'expanded': false,
-        'loading': false,
-        'items': [],
-        'label': 'Other4',
-        'path': '/other/test3',
-        'namespace': 'other'
-      }],
+      'items': [
+        {
+          'selected': true,
+          'expanded': false,
+          'loading': false,
+          'items': [],
+          'label': 'My Test',
+          'path': '/mytest/test',
+          'namespace': 'mytest'
+        },
+        {
+          'selected': false,
+          'expanded': false,
+          'loading': false,
+          'items': [],
+          'icon': '',
+          'label': 'Other',
+          'path': '/other/test',
+          'namespace': 'other'
+        },
+        {
+          'selected': false,
+          'expanded': false,
+          'loading': false,
+          'items': [],
+          'icon': '',
+          'label': 'Other2',
+          'path': '/other/test2',
+          'namespace': 'other'
+        },
+        {
+          'selected': false,
+          'expanded': false,
+          'loading': false,
+          'items': [],
+          'label': 'Other4',
+          'path': '/other/test3',
+          'namespace': 'other'
+        }
+      ],
       'icon': IconCode,
       'label': 'Other',
       'path': '/other/test',
@@ -93,12 +95,42 @@ const menu = [
     },
     {
       'selected': false,
+      'expanded': true,
+      'loading': false,
+      'items': [
+        {
+          'selected': false,
+          'expanded': false,
+          'loading': false,
+          'items': [],
+          'label': 'Other3/1',
+          'path': '/other3/test1',
+          'namespace': 'other3'
+        },
+        {
+          'selected': false,
+          'expanded': false,
+          'loading': false,
+          'items': [],
+          'label': 'Other3/2',
+          'path': '/other3/test2',
+          'namespace': 'other3'
+        },
+      ],
+      'icon': IconCluster,
+      'label': 'Other3',
+      'path': '/other3',
+      'namespace': 'other3',
+      'forceToUseHrefAttribute': true
+    },
+    {
+      'selected': false,
       'expanded': false,
       'loading': false,
       'items': [],
       'icon': IconTrash,
       'label': 'Other4',
-      'path': '/other/test3',
+      'path': '/other/test4',
       'namespace': 'other'
     },
     {


### PR DESCRIPTION
Now we don't render the href attribute if the menu item has children.
If you want to use the old behavior, you can set the `forceToUseHrefAttribute` parameter to true. 
